### PR TITLE
Fix Linux build

### DIFF
--- a/Source/GraphFormatter/Private/FastAndSimplePositioningStrategy.cpp
+++ b/Source/GraphFormatter/Private/FastAndSimplePositioningStrategy.cpp
@@ -174,7 +174,7 @@ void FFastAndSimplePositioningStrategy::DoHorizontalCompaction()
 		{
 			auto& RootNode = RootMap[Node];
 			const float Shift = ShiftMap[SinkMap[RootNode]];
-			if (IsLeftDirection && Shift < FLT_MAX || !IsLeftDirection&& Shift > -FLT_MAX)
+			if ((IsLeftDirection && Shift < FLT_MAX) || (!IsLeftDirection && Shift > -FLT_MAX))
 			{
 				(*XMap)[Node] = (*XMap)[Node] + Shift;
 			}


### PR DESCRIPTION
When building on Linux I get following warnings:
```
/mnt/nvme/projects/<project>/Plugins/GraphFormatter/Source/GraphFormatter/Private/FastAndSimplePositioningStrategy.cpp:177:24: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
                        if (IsLeftDirection && Shift < FLT_MAX || !IsLeftDirection&& Shift > -FLT_MAX)
                            ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~ ~~
/mnt/nvme/projects/<project>/Plugins/GraphFormatter/Source/GraphFormatter/Private/FastAndSimplePositioningStrategy.cpp:177:24: note: place parentheses around the '&&' expression to silence this warning
                        if (IsLeftDirection && Shift < FLT_MAX || !IsLeftDirection&& Shift > -FLT_MAX)
                            ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/mnt/nvme/projects/<project>/Plugins/GraphFormatter/Source/GraphFormatter/Private/FastAndSimplePositioningStrategy.cpp:177:62: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
                        if (IsLeftDirection && Shift < FLT_MAX || !IsLeftDirection&& Shift > -FLT_MAX)
                                                               ~~ ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
/mnt/nvme/projects/<project>/Plugins/GraphFormatter/Source/GraphFormatter/Private/FastAndSimplePositioningStrategy.cpp:177:62: note: place parentheses around the '&&' expression to silence this warning
                        if (IsLeftDirection && Shift < FLT_MAX || !IsLeftDirection&& Shift > -FLT_MAX)
```

Guessed the correct/intended logic to fix it feel free to correct me if I am wrong