### PR TITLE
Fix UnrealBuildTool warnings for UE5

### DIFF
--- a/GraphFormatter.uplugin
+++ b/GraphFormatter.uplugin
@@ -22,10 +22,15 @@
 			"LoadingPhase": "PostEngineInit",
 			"WhitelistPlatforms": [
 				"Win64",
-				"Win32",
 				"Mac",
 				"Linux"
 			]
+		}
+	],
+	"Plugins": [
+		{
+			"Name": "Metasound",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
A handful of fixes for UE5:
- Win32 is no longer a valid platform
- Listing AudioWidgets, AudioSynesthesia, MetasoundEditor and MetasoundFrontend require modules that are not loaded by default.