### PR TITLE
Added support for formatting graphs in an automated fashion

### DIFF
--- a/Source/GraphFormatter/Private/FormatterModule.cpp
+++ b/Source/GraphFormatter/Private/FormatterModule.cpp
@@ -26,6 +26,8 @@ class FFormatterModule : public IGraphFormatterModule
 {
     virtual void StartupModule() override;
     virtual void ShutdownModule() override;
+    virtual void FormatGraphAutomated(TObjectPtr<UObject> Object) override;
+
     void HandleAssetEditorOpened(UObject* Object, IAssetEditorInstance* Instance);
     void HandleEditorWidgetCreated(UObject* Object);
     void HandleAssetEditorClosed(UObject* Object, EAssetEditorCloseReason Reason);
@@ -361,6 +363,28 @@ void FFormatterModule::ShutdownModule()
         GEditor->GetEditorSubsystem<UAssetEditorSubsystem>()->OnAssetOpenedInEditor().RemoveAll(this);
     }
     FFormatterStyle::Shutdown();
+}
+
+void FFormatterModule::FormatGraphAutomated(const TObjectPtr<UObject> Object)
+{
+	const auto AssetEditor = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>();
+	
+	AssetEditor->OpenEditorForAsset(Object);
+
+	const auto EditorInstance = AssetEditor->FindEditorForAsset(Object.Get(), false);
+	
+	if(!EditorInstance)
+	{
+		return;
+	}
+
+	if (SGraphEditor* Editor = FindEditorForObject(Object.Get()))
+	{
+		FFormatter::Instance().SetCurrentEditor(Editor, Object.Get());
+		FFormatter::Instance().Format();
+	}
+
+	EditorInstance->CloseWindow();
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GraphFormatter/Public/FormatterModule.h
+++ b/Source/GraphFormatter/Public/FormatterModule.h
@@ -37,4 +37,9 @@ public:
     {
         return FModuleManager::Get().IsModuleLoaded("GraphFormatter");
     }
+
+    virtual void FormatGraphAutomated(TObjectPtr<UObject> Object)
+    {
+        //Do nothing
+    }
 };


### PR DESCRIPTION
Some trickery, but works fine. Basically opens an asset in the editor, runs the formatter, then closes the asset again.

Usage would be something like:
```
IGraphFormatterModule::Get().FormatGraphAutomated(SoundCueInstance.Get());
```
I've used this (albit in an earlier stage when there was still the FormatterHacker file :P) extensively to format thousands of dynamically generated Materials and SoundCues.