### PR TITLE
Fixed issue where an automated graph format results in a null pointer exception

### DIFF
--- a/Source/GraphFormatter/Private/FormatterModule.cpp
+++ b/Source/GraphFormatter/Private/FormatterModule.cpp
@@ -18,6 +18,7 @@
 #include "GraphEditorSettings.h"
 #include "ScopedTransaction.h"
 #include "FormatterLog.h"
+#include "SGraphPanel.h"
 #include "Widgets/Input/SSpinBox.h"
 
 #define LOCTEXT_NAMESPACE "GraphFormatter"
@@ -380,6 +381,8 @@ void FFormatterModule::FormatGraphAutomated(const TObjectPtr<UObject> Object)
 
 	if (SGraphEditor* Editor = FindEditorForObject(Object.Get()))
 	{
+		Editor->GetGraphPanel()->Update();
+
 		FFormatter::Instance().SetCurrentEditor(Editor, Object.Get());
 		FFormatter::Instance().Format();
 	}


### PR DESCRIPTION
Ran into a situation where I coincidentally had to use the "new version" and run into an issue.

The Graph does not populate the nodes before the first Update-call (which never happens if you run from an automated context). In my old version (the FormatterHacker with delegates) I manually called the `Update()` method and this now still solves the issue.

PS. Unrelated to graphformatter, but SoundClasses don't have their node positions persisted :/ Any idea why? I can't spot any real difference between other graphs. Almost seems like it has its own auto formatter on load... 