### PR TITLE
fixes -Wlogical-op-parentheses under linux

### DIFF
--- a/Source/GraphFormatter/Private/UEGraphAdapter.cpp
+++ b/Source/GraphFormatter/Private/UEGraphAdapter.cpp
@@ -148,9 +148,9 @@ bool UEGraphAdapter::GetNodesConnectCenter(const TSet<UEdGraphNode*>& SelectedNo
             {
                 continue;
             }
-            if (Option == EFormatterPinDirection::In && Pin->Direction == EGPD_Input ||
-                Option == EFormatterPinDirection::Out && Pin->Direction == EGPD_Output ||
-                Option == EFormatterPinDirection::InOut)
+            if ((Option == EFormatterPinDirection::In && Pin->Direction == EGPD_Input) ||
+                (Option == EFormatterPinDirection::Out && Pin->Direction == EGPD_Output) ||
+                (Option == EFormatterPinDirection::InOut))
             {
                 for (auto LinkedPin : Pin->LinkedTo)
                 {


### PR DESCRIPTION
Under Linux, there are warning errors which are resolved with this commit.

In file included from /mnt/local_disk/Plugin_temp/GraphFormatter/HostProject/Plugins/GraphFormatter/Intermediate/Build/Linux/x64/UnrealEditor/Development/GraphFormatter/Module.GraphFormatter.cpp:19: /mnt/local_disk/Plugin_temp/GraphFormatter/HostProject/Plugins/GraphFormatter/Source/GraphFormatter/Private/UEGraphAdapter.cpp:151:54: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
            if (Option == EFormatterPinDirection::In && Pin->Direction == EGPD_Input ||
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~
/mnt/local_disk/Plugin_temp/GraphFormatter/HostProject/Plugins/GraphFormatter/Source/GraphFormatter/Private/UEGraphAdapter.cpp:151:54: note: place parentheses around the '&&' expression to silence this warning
            if (Option == EFormatterPinDirection::In && Pin->Direction == EGPD_Input ||
                                                     ^